### PR TITLE
Add roxygen docs for undocumented secondary payload helpers

### DIFF
--- a/R/build_secondary_biplots.R
+++ b/R/build_secondary_biplots.R
@@ -404,7 +404,17 @@ add_axis_pred_payload <- function(payload, x, EZ = FALSE) {
   return(list(traces))
 }
 
-
+#' Build traces for proportion of variance explained
+#'
+#' @param x A `bipl5` object containing eigenvalues, loadings, and dimensions
+#' @param axis Plotly x-axis id for the secondary panel
+#' @param yaxis Plotly y-axis id for the secondary panel
+#' @param title Legacy argument retained for compatibility
+#' @param meta_key Metadata tag used by client-side panel switching logic
+#' @param line_color Colour applied to the `% Individual` line trace
+#'
+#' @return A list containing stacked bar and line traces for variance components
+#' @noRd
 add_prop_variance_payload<-function(x,
                                     axis = "x3", yaxis = "y3",
                                     title = "Proportion of variance",
@@ -468,6 +478,16 @@ add_prop_variance_payload<-function(x,
 }
 
 
+#' Build scree-plot traces for the secondary panel
+#'
+#' @param x A `bipl5` object with `eigenvalues` and `p` populated
+#' @param axis Plotly x-axis id for the secondary panel
+#' @param yaxis Plotly y-axis id for the secondary panel
+#' @param meta_key Metadata tag used by client-side panel switching logic
+#' @param line_color Colour applied to the scree line trace
+#'
+#' @return A list containing a single scree trace in Plotly.addTraces format
+#' @noRd
 add_scree_payload <- function(x,
                               axis = "x3",
                               yaxis = "y3",


### PR DESCRIPTION
### Motivation
- Two helper functions used to build plotly payloads for secondary panels lacked roxygen documentation, which breaks documentation completeness and roxygen-based checks.

### Description
- Added internal roxygen documentation blocks (description, `@param`, `@return`, and `@noRd`) for `add_prop_variance_payload` and `add_scree_payload` in `R/build_secondary_biplots.R` without changing runtime behavior.

### Testing
- Ran a local Python scan across `R/*.R` to detect function definitions missing a preceding roxygen block, which returned no results indicating the undocumented functions were addressed (succeeded).
- Attempted to parse the modified R file with `Rscript -e "parse(file='R/build_secondary_biplots.R')"` but `Rscript` is unavailable in this environment (could not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698def1e11dc8333a2d257ff15f86d80)